### PR TITLE
Allow use of config_path for system config path.

### DIFF
--- a/src/app/code/community/AvS/ScopeHint/Block/AdminhtmlSystemConfigFormField.php
+++ b/src/app/code/community/AvS/ScopeHint/Block/AdminhtmlSystemConfigFormField.php
@@ -135,6 +135,10 @@ class AvS_ScopeHint_Block_AdminhtmlSystemConfigFormField
      */
     protected function _getConfigCode(Varien_Data_Form_Element_Abstract $element)
     {
+        if (isset($element->field_config->config_path)) {
+            return (string) $element->field_config->config_path;
+        }
+
         $configCode = preg_replace('#\[value\](\[\])?$#', '', $element->getName());
         $configCode = str_replace('[fields]', '', $configCode);
         $configCode = str_replace('groups[', '[', $configCode);


### PR DESCRIPTION
The config_path for a system configuration setting can be specified in
system.xml. If this field is specified it overrides the path field for
the config option. Detect if config_path is present for a field and
return it rather than generating a path from it's position in the xml.
