### PR TITLE
Skip extending scope hint title on empty checkbox options value

### DIFF
--- a/src/app/code/community/AvS/ScopeHint/Block/AdminhtmlSystemConfigFormField.php
+++ b/src/app/code/community/AvS/ScopeHint/Block/AdminhtmlSystemConfigFormField.php
@@ -72,6 +72,9 @@ class AvS_ScopeHint_Block_AdminhtmlSystemConfigFormField
             if ($options) {
                 $defTextArr = array();
                 foreach ($options as $k => $v) {
+                    if (!isset($v['value'])) {
+                        continue;
+                    }
                     if ($isMultiple) {
                         if (is_array($v['value']) && in_array($k, $v['value'])) {
                             $defTextArr[] = $v['label'];


### PR DESCRIPTION
I got a E_NOTICE, when viewing paypal express configuration section in CE 1.8 and fixed it with that little change.