### PR TITLE
Fix notice when category attribute returns multidimension array

### DIFF
--- a/src/app/code/community/AvS/ScopeHint/Block/Hint.php
+++ b/src/app/code/community/AvS/ScopeHint/Block/Hint.php
@@ -188,12 +188,18 @@ class AvS_ScopeHint_Block_Hint extends Mage_Adminhtml_Block_Abstract
                 if (is_null($scope)) {
                     $value = $this->_getCategory()->getData($attributeName);
                     if (is_array($value)) {
+                        if (isset($value[0]) && is_array($value[0])) {
+                            return '';
+                        }
                         return implode(',', $value);
                     }
                     return $value;
                 } else if ($scope instanceof Mage_Core_Model_Store) {
                     $value = $this->_getCategory($scope)->getData($attributeName);
                     if (is_array($value)) {
+                        if (isset($value[0]) && is_array($value[0])) {
+                            return '';
+                        }
                         return implode(',', $value);
                     }
                     return $value;


### PR DESCRIPTION
A notice is thrown when $value is multidimension array. Same behaviour as in product section.