### PR TITLE
Remove newlines from tooltip content

### DIFF
--- a/src/js/scopehint/tooltip.js
+++ b/src/js/scopehint/tooltip.js
@@ -94,6 +94,9 @@ Tooltip.prototype = {
 
         this.options = options;
 
+        // Remove newlines from tooltip
+        tool_tip = tool_tip.replace(/(\r\n|\n|\r)/gm,"");
+
         // use the supplied tooltip element or create our own div
         if ($(tool_tip)) {
             this.tool_tip = $(tool_tip);


### PR DESCRIPTION
Prevents the following error:
Uncaught DOMException: Failed to execute 'querySelector' on 'Document': '[id="Changes in:<br />Store View: MyStore:<br />Some text
with a new line"]' is not a valid selector.